### PR TITLE
Allow nested quotes in string interpolations

### DIFF
--- a/syntax/bicep.vim
+++ b/syntax/bicep.vim
@@ -49,7 +49,7 @@ syn keyword bicepValueNull null
 syn match   bicepValueDec  /\<[0-9]\+\([kKmMgG]b\?\)\?\>/
 
 syn region bicepValueString  start=/'/ skip=/\\\\\|\\'/ end=/'/ contains=bicepStringInterp,bicepEscape
-syn region bicepStringInterp start=/${/ end=/}/ contained
+syn region bicepStringInterp start=/${/ end=/}/ contained contains=bicepValueString
 syn match  bicepEscape       /\\n/ contained
 syn match  bicepEscape       /\\r/ contained
 


### PR DESCRIPTION
This fixes an issue where string interpolations containing single quotes (like function calls with string parameters) were incorrectly terminating the outer string.

Example:
```bicep
var object = {
  uri: 'https://${function_app.properties.hostNames[0]}/api/${i.function_name}?code=${listKeys('${function_app.id}/host/default', function_app.apiVersion).masterKey}'
}
```